### PR TITLE
Removing a11y rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,6 @@ module.exports = {
     'react/no-find-dom-node': 0,
     'react/require-default-props': 0,
     'react/no-typos': 1,
-    'jsx-a11y/no-static-element-interactions': 0,
     'no-underscore-dangle': 0,
     'no-unused-expressions': [1, { allowTernary: true }],
 


### PR DESCRIPTION
We should not be turning this rule off as it's a big fat smell when it comes to a11y. 

Carbon violates this rule quite a bit so until we fix it we'll have to just override it within Carbon (when we consume this config that is).